### PR TITLE
Updates installation URLs to use get.mkh.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A security-first Zsh library that provides platform, architecture, and environme
 
 ```bash
 # Download and source in your script
-curl -fsSL https://github.com/Khodaparastan/zsh-runtime-detect/blob/main/zrd.zsh -o zrd.zsh
+curl -fsSL get.mkh.sh/zrd -o zrd.zsh
 source zrd.zsh
 ```
 
@@ -272,10 +272,10 @@ zsh-runtime-detect follows a layered architecture designed for reliability, perf
 
 ```bash
 # Download to your project
-curl -fsSL https://raw.githubusercontent.com/khodaparastan/zsh-runtime-detect/main/zrd.zsh -o zrd.zsh
+curl -fsSL get.mkh.sh/zrd -o zrd.zsh
 
 # Or install system-wide
-sudo curl -fsSL https://raw.githubusercontent.com/khodaparastan/zsh-runtime-detect/main/zrd.zsh -o /usr/local/lib/zrd.zsh
+sudo curl -fsSL get.mkh.sh/zrd -o /usr/local/lib/zrd.zsh
 ```
 
 ### Method 2: Git Clone

--- a/README.md
+++ b/README.md
@@ -272,10 +272,10 @@ zsh-runtime-detect follows a layered architecture designed for reliability, perf
 
 ```bash
 # Download to your project
-curl -fsSL https://raw.githubusercontent.com/khodaparastan/zsh-runtime-detect/main/zrd.zsh -o zrd.zsh
+curl -fsSL https://get.mkh.sh/zrd -o zrd.zsh
 
 # Or install system-wide
-sudo curl -fsSL https://raw.githubusercontent.com/khodaparastan/zsh-runtime-detect/main/zrd.zsh -o /usr/local/lib/zrd.zsh
+sudo curl -fsSL https://get.mkh.sh/zrd -o /usr/local/lib/zrd.zsh
 ```
 
 ### Method 2: Git Clone


### PR DESCRIPTION
Updates the installation instructions in the README to use the `get.mkh.sh` URL for downloading the `zrd.zsh` script. This change simplifies the installation process by using a dedicated URL for the script.